### PR TITLE
URL tracking

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,9 @@
 class ApplicationController < ActionController::API
-
   def authorize
     true
+  end
+
+  def find_campaign
+    @campaign = Campaign.find_by!(uid: params[:campaign_id])
   end
 end

--- a/app/controllers/opens_controller.rb
+++ b/app/controllers/opens_controller.rb
@@ -8,11 +8,4 @@ class OpensController < ApplicationController
       type: "image/gif", disposition: "inline"
     )
   end
-
-
-  private
-
-  def find_campaign
-    @campaign = Campaign.find_by!(uid: params[:campaign_id])
-  end
 end

--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -1,0 +1,8 @@
+class UrlsController < ApplicationController
+  before_action :find_campaign
+
+  def track
+    UrlClick.track(@campaign, recipient_id: params[:recipient_id], url: params[:url])
+    redirect_to params[:url]
+  end
+end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -1,6 +1,7 @@
 class Campaign < ApplicationRecord
   before_create :generate_uid
   has_many :opens
+  has_many :url_clicks
 
   validates :name, presence: true
 

--- a/app/models/url_click.rb
+++ b/app/models/url_click.rb
@@ -1,0 +1,29 @@
+class UrlClick < ApplicationRecord
+  belongs_to :campaign, counter_cache: true
+
+  validates :campaign_id, :recipient_id, :url, presence: true
+  before_save :set_timestamps
+  before_save :increment_counter
+
+  class << self
+    def track(campaign, recipient_id:, url:)
+      click = UrlClick.find_or_initialize_by(campaign: campaign, recipient_id: recipient_id, url: url)
+      click.save
+      click
+    end
+  end
+
+  private
+
+  def set_timestamps
+    unless first_clicked_at
+      self.first_clicked_at = Time.now
+    end
+
+    self.last_clicked_at = Time.now
+  end
+
+  def increment_counter
+    self.clicks_count += 1
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   get 'track', to: 'opens#track'
+  get 'clicks', to: 'urls#track'
 
   resources :campaigns, only: [:create, :show]
+  resources :urls, only: [:show]
 end

--- a/db/migrate/20170207114138_create_campaigns.rb
+++ b/db/migrate/20170207114138_create_campaigns.rb
@@ -4,6 +4,7 @@ class CreateCampaigns < ActiveRecord::Migration[5.0]
       t.string :name
       t.string :uid
       t.integer :opens_count, default: 0
+      t.integer :url_clicks_count, default: 0
 
       t.timestamps
     end

--- a/db/migrate/20170208153146_create_url_clicks.rb
+++ b/db/migrate/20170208153146_create_url_clicks.rb
@@ -1,0 +1,14 @@
+class CreateUrlClicks < ActiveRecord::Migration[5.0]
+  def change
+    create_table :url_clicks do |t|
+      t.string :url
+      t.datetime :first_clicked_at
+      t.datetime :last_clicked_at
+      t.string :recipient_id
+      t.integer :clicks_count, default: 0
+      t.references :campaign, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170207114348) do
+ActiveRecord::Schema.define(version: 20170208153146) do
 
   create_table "campaigns", force: :cascade do |t|
     t.string   "name"
     t.string   "uid"
-    t.integer  "opens_count", default: 0
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.integer  "opens_count",      default: 0
+    t.integer  "url_clicks_count", default: 0
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
   end
 
   create_table "opens", force: :cascade do |t|
@@ -29,6 +30,18 @@ ActiveRecord::Schema.define(version: 20170207114348) do
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
     t.index ["campaign_id"], name: "index_opens_on_campaign_id"
+  end
+
+  create_table "url_clicks", force: :cascade do |t|
+    t.string   "url"
+    t.datetime "first_clicked_at"
+    t.datetime "last_clicked_at"
+    t.string   "recipient_id"
+    t.integer  "clicks_count",     default: 0
+    t.integer  "campaign_id"
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.index ["campaign_id"], name: "index_url_clicks_on_campaign_id"
   end
 
 end

--- a/spec/controllers/urls_controller_spec.rb
+++ b/spec/controllers/urls_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe UrlsController, type: :controller do
+
+  describe "GET #get" do
+    it "returns http success" do
+      get :get
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/models/url_click_spec.rb
+++ b/spec/models/url_click_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+describe UrlClick do
+  
+end

--- a/spec/requests/url_clicks_spec.rb
+++ b/spec/requests/url_clicks_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe 'Url clicks' do
+  context 'campaign does not exist' do
+    before do
+      @campaign = Campaign.create(name: 'demo')
+
+      get '/clicks', params: { campaign_id: @campaign.uid, recipient_id: 1, url: 'http://example.com' }
+    end
+
+    it 'tracks opens' do
+      expect(@campaign.reload.url_clicks.count).to eq(1)
+    end
+
+    it 'redirects to passed url' do
+      expect(response).to redirect_to('http://example.com')
+    end
+  end
+
+  context 'campaign does not exist' do
+    it 'raises not found' do
+      expect{
+        get '/track', params: { recipient_id: 1, url: 'http://example.com' }
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
PR allows tracking URLs. Service first associated the URL with a campaign and member before redirecting.

To use this service pass the URL along with recipient ID and campaign ID like so:

`http://service.com/track?recipient_id=:recipient_id&campaign_id=:campaign_id&url=http://google.com`

Service will track total number of clicks and total number of unique clicks.